### PR TITLE
vk-ab-testingのen用を追加

### DIFF
--- a/vk-admin-banners.json
+++ b/vk-admin-banners.json
@@ -10,6 +10,15 @@
 	},
 	{
 		"type": "plugin",
+		"slug": "vk-ab-testing/vk-ab-testing.php",
+		"image_file": "ad_banner-vk-ab-testing-en.jpg",
+		"link_url": "https://vektor-inc.co.jp/en/plugins/vk-ab-testing/?rel=vkadmin",
+		"alt": "VK AB Testing",
+		"language": "en",
+		"admin_url": false
+	},
+	{
+		"type": "plugin",
 		"slug": "vk-dynamic-if-block/vk-dynamic-if-block.php",
 		"image_file": "ad_banner-vk-dinamic-if-block-ja.jpg",
 		"link_url": "https://www.vektor-inc.co.jp/service/wordpress-plugins/vk-dynamic-if-block/?rel=vkadmin",


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-admin-banners/issues/9

## どういう変更をしたか？
関連：https://github.com/vektor-inc/vk-admin-banners/pull/8

vk-abtestingのen用の表記を追加しました。念の為、チェックをしていただいた方が良いかな？と思いましたのでプルリクにします🙇1人チェックでOKです。OKでしたらmergeしてください
